### PR TITLE
Enable Code Snippet Execution for Lesson 3 in R

### DIFF
--- a/app.py
+++ b/app.py
@@ -355,7 +355,7 @@ def main():
             st.markdown(post_md + "\n")
         # Do NOT output after_exercise markdown (no duplication)
 
-    elif selected_mod.stem == "02_r":
+    elif selected_mod.stem in ("02_r", "03_r"):
         # Inline parse and render: markdown up to ### Exercise, with code block runners for R
         code_block_pattern = re.compile(r"```r(.*?)```", re.DOTALL | re.IGNORECASE)
         exercise_idx = md_text.find("### Exercise")


### PR DESCRIPTION
This pull request adds functionality to execute R code snippets in the 3rd lesson. By modifying the conditional check in `app.py`, we allow the existing code block runners for R to function for both the 2nd and 3rd lessons. This updates the behavior consistent with lesson 1, ensuring that there is no visible option to run the code snippets, and removes any indication of a "# no-run" comment.

---

> This pull request was co-created with Cosine Genie

Original Task: [data-science-teaching-cosine/wdx08hafkq3p](https://cosine.sh/5wdpuhj5zgn0/data-science-teaching-cosine/task/wdx08hafkq3p)
Author: James
