### PR TITLE
Fix Ace Editor Disappearance in Streamlit App

### DIFF
--- a/app.py
+++ b/app.py
@@ -488,8 +488,8 @@ def main():
         flash_container = st.empty()
 
         if st.button("Run Exercise", key=f"run_exercise_{mod_id}"):
-            # Always capture latest code from editor at button press
-            user_code = editor if editor is not None else exercise_code
+            # Always capture latest code from session_state at button press
+            user_code = st.session_state.get(exercise_key, exercise_code)
             # Custom logic for 01_python -- check for correct `squares`.
             if selected_mod.stem == "01_python":
                 import io, contextlib, traceback
@@ -556,6 +556,7 @@ def main():
                 # (persist() saves user progress for both dev & normal mode)
                 persist()
             else:
+                user_code = st.session_state.get(exercise_key, exercise_code)
                 output, error = run_code(user_code, lang=exercise_lang or "python")
                 st.text_area("Exercise Output", output + (f"\n[Error]: {error}" if error else ""), height=150)
                 # Update progress

--- a/app.py
+++ b/app.py
@@ -449,6 +449,9 @@ def main():
         if exercise_key not in st.session_state:
             st.session_state[exercise_key] = exercise_code  # initialize with starter code
 
+        ace_widget_key = f"{exercise_key}_ace"
+        fallback_widget_key = f"{exercise_key}_fallback"
+
         if (exercise_lang or "").lower() == "python":
             if USE_ACE_EDITOR:
                 try:
@@ -457,7 +460,7 @@ def main():
                         value=st.session_state[exercise_key],
                         language="python",
                         theme="solarized_light",
-                        key=exercise_key,
+                        key=ace_widget_key,
                         height=200,
                         min_lines=8,
                         max_lines=30,
@@ -465,17 +468,17 @@ def main():
                     )
                     # Fallback if Ace fails to render or returns empty string/None
                     if not ace_val:
-                        editor = st.text_area("Edit & Run Your Solution", st.session_state[exercise_key], height=200, key=f"{exercise_key}_fallback")
+                        editor = st.text_area("Edit & Run Your Solution", st.session_state[exercise_key], height=200, key=fallback_widget_key)
                     else:
                         editor = ace_val
                 except Exception:
-                    editor = st.text_area("Edit & Run Your Solution", st.session_state[exercise_key], height=200, key=f"{exercise_key}_fallback")
+                    editor = st.text_area("Edit & Run Your Solution", st.session_state[exercise_key], height=200, key=fallback_widget_key)
             else:
-                editor = st.text_area("Edit & Run Your Solution", st.session_state[exercise_key], height=200, key=f"{exercise_key}_fallback")
+                editor = st.text_area("Edit & Run Your Solution", st.session_state[exercise_key], height=200, key=fallback_widget_key)
         else:
-            editor = st.text_area("Edit & Run Your Solution", st.session_state[exercise_key], height=200, key=f"{exercise_key}_fallback")
+            editor = st.text_area("Edit & Run Your Solution", st.session_state[exercise_key], height=200, key=fallback_widget_key)
 
-        # --- Update session_state with latest editor content ---
+        # --- Persist latest content ---
         # This ensures user edits are preserved across reruns.
         if editor is not None:
             st.session_state[exercise_key] = editor

--- a/app.py
+++ b/app.py
@@ -444,12 +444,17 @@ def main():
         if exercise_code is None:
             exercise_code = ""
         # Use ACE editor for Python if enabled; otherwise always use text_area
+        # --- Robust Ace editor state persistence ---
+        # Always persist editor content in session_state to survive reruns or example runs!
+        if exercise_key not in st.session_state:
+            st.session_state[exercise_key] = exercise_code  # initialize with starter code
+
         if (exercise_lang or "").lower() == "python":
             if USE_ACE_EDITOR:
                 try:
                     from streamlit_ace import st_ace
                     ace_val = st_ace(
-                        value=exercise_code,
+                        value=st.session_state[exercise_key],
                         language="python",
                         theme="solarized_light",
                         key=exercise_key,
@@ -460,16 +465,22 @@ def main():
                     )
                     # Fallback if Ace fails to render or returns empty string/None
                     if not ace_val:
-                        editor = st.text_area("Edit & Run Your Solution", exercise_code, height=200, key=exercise_key)
+                        editor = st.text_area("Edit & Run Your Solution", st.session_state[exercise_key], height=200, key=f"{exercise_key}_fallback")
                     else:
                         editor = ace_val
                 except Exception:
-                    editor = st.text_area("Edit & Run Your Solution", exercise_code, height=200, key=exercise_key)
+                    editor = st.text_area("Edit & Run Your Solution", st.session_state[exercise_key], height=200, key=f"{exercise_key}_fallback")
             else:
-                editor = st.text_area("Edit & Run Your Solution", exercise_code, height=200, key=exercise_key)
+                editor = st.text_area("Edit & Run Your Solution", st.session_state[exercise_key], height=200, key=f"{exercise_key}_fallback")
         else:
-            editor = st.text_area("Edit & Run Your Solution", exercise_code, height=200, key=exercise_key)
-        user_code = editor if editor is not None else exercise_code
+            editor = st.text_area("Edit & Run Your Solution", st.session_state[exercise_key], height=200, key=f"{exercise_key}_fallback")
+
+        # --- Update session_state with latest editor content ---
+        # This ensures user edits are preserved across reruns.
+        if editor is not None:
+            st.session_state[exercise_key] = editor
+
+        user_code = st.session_state[exercise_key]
 
         # --- Inline flash message placeholder: appears just under code editor/run area ---
         # We use a container here so the flash message (success/error/info) is always shown in-context,


### PR DESCRIPTION
This pull request addresses the issue where the Streamlit Ace editor disappears after executing a code example. The modifications ensure that the editor's content is preserved across reruns by utilizing `st.session_state`. Specifically, I've made the following changes:

1. Initialized the editor state in `st.session_state` if it does not exist.
2. Updated the `st_ace()` calls to use the value from `st.session_state`, allowing it to retain user edits and persist through various interactions.
3. Ensured that a consistent fallback approach is provided to handle the editor state between Ace and the text area.

These changes prevent the Ace editor from being removed from the DOM during reruns, improving the user experience when executing multiple code examples.

---

> This pull request was co-created with Cosine Genie

Original Task: [data-science-teaching-cosine/70z6ks1oymkl](https://cosine.sh/5wdpuhj5zgn0/data-science-teaching-cosine/task/70z6ks1oymkl)
Author: James
