### PR TITLE
Replace Ace Editor with Monaco Editor

### DIFF
--- a/app.py
+++ b/app.py
@@ -451,7 +451,6 @@ def main():
                     monaco_val = st_monaco(
                         value=exercise_code,
                         language="python",
-                        theme="vs-dark",
                         height="400px",
                         key=exercise_key,
                     )

--- a/app.py
+++ b/app.py
@@ -28,7 +28,7 @@ from utils.auth import (
 )
 
 DEV_MODE = '--dev' in sys.argv
-USE_ACE_EDITOR = True  # Feature flag for Ace editor, default ON
+USE_MONACO_EDITOR = True  # Feature flag for Monaco editor, default ON
 
 def handle_auth():
     """Streamlit UI for login/register/logout. Sets st.session_state['logged_in'] and ['username']."""
@@ -443,26 +443,19 @@ def main():
         exercise_key = f"exercise_{mod_id}"
         if exercise_code is None:
             exercise_code = ""
-        # Use ACE editor for Python if enabled; otherwise always use text_area
+        # Use Monaco editor for Python if enabled; otherwise always use text_area
         if (exercise_lang or "").lower() == "python":
-            if USE_ACE_EDITOR:
+            if USE_MONACO_EDITOR:
                 try:
-                    from streamlit_ace import st_ace
-                    ace_val = st_ace(
+                    from streamlit_monaco import st_monaco
+                    monaco_val = st_monaco(
                         value=exercise_code,
                         language="python",
-                        theme="solarized_light",
+                        theme="vs-dark",
+                        height="400px",
                         key=exercise_key,
-                        height=200,
-                        min_lines=8,
-                        max_lines=30,
-                        font_size=16,
                     )
-                    # Fallback if Ace fails to render or returns empty string/None
-                    if not ace_val:
-                        editor = st.text_area("Edit & Run Your Solution", exercise_code, height=200, key=exercise_key)
-                    else:
-                        editor = ace_val
+                    editor = monaco_val if monaco_val is not None else exercise_code
                 except Exception:
                     editor = st.text_area("Edit & Run Your Solution", exercise_code, height=200, key=exercise_key)
             else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,5 @@ scikit-learn==1.5.0
 # boto3==1.34.108
 # tensorflow==2.16.1
 # rpy2 -- for R/Python interoperability (optional; install with: pip install rpy2)
-streamlit-ace==0.1.1
+# streamlit-ace==0.1.1
+streamlit-monaco==0.1.3


### PR DESCRIPTION
This PR replaces the existing Ace editor with the Monaco editor in lesson one code snippets. The change addresses a bug where previously executed snippets would disappear upon running another snippet. Monaco editor is now set as the default editor for Python code, ensuring improved functionality and user experience. The necessary dependencies have been updated in `requirements.txt` to include `streamlit-monaco` and the old `streamlit-ace` dependency has been commented out.

---

> This pull request was co-created with Cosine Genie

Original Task: [data-science-teaching-cosine/l0gm7rx5asxa](https://cosine.sh/5wdpuhj5zgn0/data-science-teaching-cosine/task/l0gm7rx5asxa)
Author: James
