### PR TITLE
Ignore RuntimeError in Error Handling Example

### DIFF
--- a/modules/beginner/01_python.md
+++ b/modules/beginner/01_python.md
@@ -396,7 +396,7 @@ try:
     val = float("not a number")
 except ValueError as e:
     print(f"Conversion failed: {e}")
-    raise RuntimeError("Parsing error") from e
+    # raise RuntimeError("Parsing error") from e
 else:
     print("Conversion succeeded!")
 finally:


### PR DESCRIPTION
This pull request modifies the error handling snippet in lesson 1 to ignore the RuntimeError raised during the conversion failure. Instead of raising a new error, we allow the original ValueError to be displayed, providing clarity on the issue without raising an additional exception.

---

> This pull request was co-created with Cosine Genie

Original Task: [data-science-teaching-cosine/vpql17g7u0gs](https://cosine.sh/5wdpuhj5zgn0/data-science-teaching-cosine/task/vpql17g7u0gs)
Author: James
