### PR TITLE
Enable Code Snippet Execution for Lesson 2

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,6 +5,9 @@ import sys
 from pathlib import Path
 from streamlit.components.v1 import html as st_html
 
+# Lessons that should have interactive Python code snippet execution
+PY_SNIPPET_LESSONS = {"01_python", "02_basic_maths_for_data_science"}
+
 def scroll_to_bottom():
     """Scroll browser viewport to page bottom (smooth, retried for Streamlit rerender timing)."""
     st_html(
@@ -285,7 +288,7 @@ def main():
     # --- Main lesson display ---
     # --- (A) Inline code block runner for Python ---
     import traceback
-    if selected_mod.stem == "01_python":
+    if selected_mod.stem in PY_SNIPPET_LESSONS:
         import matplotlib
         import matplotlib.pyplot as plt
         # Inline parse and render: markdown up to ### Exercise, with code block runners


### PR DESCRIPTION
This pull request adds the ability to run interactive Python code snippets in lesson 2, similar to how it was implemented in lesson 1. The `PY_SNIPPET_LESSONS` set has been updated to include both lesson 1 and lesson 2, allowing code snippet execution as long as they do not have the `# no-run` comment. This enhances the interactive learning experience for users.

---

> This pull request was co-created with Cosine Genie

Original Task: [data-science-teaching-cosine/69i0fnrnkdhp](https://cosine.sh/5wdpuhj5zgn0/data-science-teaching-cosine/task/69i0fnrnkdhp)
Author: James
