### PR TITLE
Use 'import numpy as np' behind the scenes in lesson 5

### DIFF
--- a/modules/beginner/05_numpy.md
+++ b/modules/beginner/05_numpy.md
@@ -48,7 +48,6 @@ print(arr)
 - These components are all perpendicular to each other (they form an orthogonal/orthonormal basis).
 
 ```python
-import numpy as np
 import matplotlib.pyplot as plt
 from sklearn.decomposition import PCA
 


### PR DESCRIPTION
This pull request modifies the 5th lesson on NumPy to ensure that 'import numpy as np' is used behind the scenes for all code examples. As a result, it simplifies the user experience by removing repetitive import statements from each example, while maintaining the necessary functionality.

---

> This pull request was co-created with Cosine Genie

Original Task: [data-science-teaching-cosine/e9nm3si4a2iz](https://cosine.sh/5wdpuhj5zgn0/data-science-teaching-cosine/task/e9nm3si4a2iz)
Author: James
